### PR TITLE
Fix icon rendering in MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,9 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.caret
   - pymdownx.details
-  - pymdownx.emoji
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
Add proper emoji configuration for pymdownx.emoji extension to enable Material Icons, FontAwesome, and Octicons rendering throughout the documentation site.

